### PR TITLE
Gradle 2.0 gives "DOCTYPE is disallowed when the feature "http://apache.org/xml/features/disallow-doctype-decl" set to true"

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.0-bin.zip

--- a/src/main/groovy/org/scoverage/OverallCheckTask.groovy
+++ b/src/main/groovy/org/scoverage/OverallCheckTask.groovy
@@ -11,13 +11,21 @@ class OverallCheckTask extends DefaultTask {
     File cobertura
     double minimumLineRate = 0.75
 
+    protected XmlParser parser;
+
+    OverallCheckTask() {
+        parser = new XmlParser()
+        parser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+        parser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+    }
+
     @TaskAction
     void requireLineCoverage() {
         def extension = ScoveragePlugin.extensionIn(project)
 
         if (cobertura == null) cobertura = new File(extension.reportDir, 'cobertura.xml')
 
-        def xml = new XmlParser().parse(cobertura)
+        def xml = parser.parse(cobertura)
         def overallLineRate = xml.attribute('line-rate').toDouble()
         def difference = (minimumLineRate - overallLineRate)
 


### PR DESCRIPTION
Gradle 2.0 gives "DOCTYPE is disallowed when the feature "http://apache.org/xml/features/disallow-doctype-decl" set to true"
