### PR TITLE
Issue #19: do not append parameters with empty value

### DIFF
--- a/src/main/groovy/org/scoverage/ScoverageExtension.groovy
+++ b/src/main/groovy/org/scoverage/ScoverageExtension.groovy
@@ -26,6 +26,8 @@ class ScoverageExtension {
     boolean highlighting = true
     /** regex for each excluded package */
     List<String> excludedPackages = []
+    /** regex for each excluded file */
+    List<String> excludedFiles = []
 
     ScoverageExtension(Project project) {
 
@@ -89,6 +91,9 @@ class ScoverageExtension {
                 plugin.add("-P:scoverage:dataDir:${extension.dataDir.absolutePath}".toString())
                 if (extension.excludedPackages) {
                     plugin.add("-P:scoverage:excludedPackages:${extension.excludedPackages.join(';')}".toString())
+                }
+                if (extension.excludedFiles) {
+                    plugin.add("-P:scoverage:excludedFiles:${extension.excludedFiles.join(';')}".toString())
                 }
                 if (extension.highlighting) {
                     plugin.add('-Yrangepos')


### PR DESCRIPTION
- this seems to only be an issue with the 2.11 compiler

PR also includes support for excluding files rather than packages
