### PR TITLE
.gitattributes added

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.java text eol=lf
+*.MD text eol=lf
+*.gradle text eol=lf
+*.groovy text eol=lf
+*.properties text eol=lf
+*.scala text eol=lf


### PR DESCRIPTION
To ensure unix-style line endings (lf). This should not affect any
non-Windows developers.