### PR TITLE
Performance Fixes

### DIFF
--- a/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
+++ b/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
@@ -25,7 +25,7 @@ class ScoveragePlugin implements Plugin<PluginAware> {
     static final String DEFAULT_REPORT_DIR = 'reports' + File.separatorChar + 'scoverage'
 
     private volatile File pluginFile = null
-    private ConcurrentHashMap<Task, Set<? extends Task>> taskDependencies = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Task, Set<? extends Task>> taskDependencies = new ConcurrentHashMap<>();
 
     @Override
     void apply(PluginAware pluginAware) {


### PR DESCRIPTION
Two performance fixes without which the build takes minutes in the configuration phase for multi-module projects with a lot of cross-references.

1. Loads the plugin just one time, instead of loading separately for each module. Debug logging showed that sometimes, this operations takes 10 sec (on some machines at least).

2. The more critical issue was in `recursiveDependenciesOf`. Without caching of the results, the same operations are repeated over and over again and it takes minutes to configure.

For a work project I have, with 16 modules, with a lot of cross-references, adding the scoverage plugin without these fixes takes 5-10 mins. The worst of it is that this is the wait time for each change in any build.gradle (e.g. adding a new dependency), which makes the work nearly impossible. After applying the fixes, there is no significant difference with the time taken without the scoverage plugin.