### PR TITLE
Collect scoverage results from all Test tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ pluginBundle {
 apply plugin: 'maven'
 apply plugin: 'groovy'
 
-sourceCompatibility = '1.6'
-targetCompatibility = '1.6'
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
 
 dependencies {
     compileOnly "org.scoverage:scalac-scoverage-plugin_2.12:1.3.1"

--- a/src/functionalTest/java/org.scoverage/ScalaSingleModuleWithMultipleTestTasksTest.java
+++ b/src/functionalTest/java/org.scoverage/ScalaSingleModuleWithMultipleTestTasksTest.java
@@ -1,0 +1,32 @@
+package org.scoverage;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ScalaSingleModuleWithMultipleTestTasksTest extends ScoverageFunctionalTest {
+    public ScalaSingleModuleWithMultipleTestTasksTest() {
+        super("scala-single-module-multiple-test-tasks");
+    }
+
+    @Test
+    public void checkScoverage() throws Exception {
+
+        AssertableBuildResult result = run("clean", ScoveragePlugin.getCHECK_NAME());
+
+        result.assertTaskSucceeded(ScoveragePlugin.getCOMPILE_NAME());
+        result.assertTaskSucceeded("reportTestScoverage");
+        result.assertTaskSucceeded("reportIntTestScoverage");
+        result.assertTaskSucceeded(ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskSucceeded(ScoveragePlugin.getCHECK_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getAGGREGATE_NAME());
+
+        assertReportFilesExist();
+        assertCoverage(100.0);
+    }
+
+    private void assertReportFilesExist() {
+
+        Assert.assertTrue(resolve(reportDir(), "index.html").exists());
+        Assert.assertTrue(resolve(reportDir(), "src/main/scala/org/hello/World.scala.html").exists());
+    }
+}

--- a/src/functionalTest/java/org.scoverage/ScalaSingleModuleWithMultipleTestTasksTest.java
+++ b/src/functionalTest/java/org.scoverage/ScalaSingleModuleWithMultipleTestTasksTest.java
@@ -9,6 +9,48 @@ public class ScalaSingleModuleWithMultipleTestTasksTest extends ScoverageFunctio
     }
 
     @Test
+    public void test() {
+
+        AssertableBuildResult result = dryRun("clean", "test");
+
+        result.assertTaskDoesntExist(ScoveragePlugin.getCOMPILE_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getAGGREGATE_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getCHECK_NAME());
+    }
+
+    @Test
+    public void build() {
+
+        AssertableBuildResult result = dryRun("clean", "build");
+
+        result.assertTaskDoesntExist(ScoveragePlugin.getCOMPILE_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getAGGREGATE_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getCHECK_NAME());
+    }
+
+    @Test
+    public void reportScoverage() {
+
+        AssertableBuildResult result = dryRun("clean", ScoveragePlugin.getREPORT_NAME());
+
+        result.assertTaskExists(ScoveragePlugin.getCOMPILE_NAME());
+        result.assertTaskExists(ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getAGGREGATE_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getCHECK_NAME());
+    }
+
+    @Test
+    public void aggregateScoverage() {
+
+        AssertableBuildResult result = runAndFail("clean", ScoveragePlugin.getAGGREGATE_NAME());
+
+        result.assertNoTasks();
+    }
+
+
+    @Test
     public void checkScoverage() throws Exception {
 
         AssertableBuildResult result = run("clean", ScoveragePlugin.getCHECK_NAME());
@@ -23,6 +65,92 @@ public class ScalaSingleModuleWithMultipleTestTasksTest extends ScoverageFunctio
         assertReportFilesExist();
         assertCoverage(100.0);
     }
+
+    @Test
+    public void checkScoverageIntTest() throws Exception {
+        AssertableBuildResult result = runAndFail("clean", "-x", "reportTestScoverage", ScoveragePlugin.getCHECK_NAME());
+
+        result.assertTaskSucceeded(ScoveragePlugin.getCOMPILE_NAME());
+        result.assertTaskDoesntExist("reportTestScoverage");
+        result.assertTaskSucceeded("reportIntTestScoverage");
+        result.assertTaskSucceeded(ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskFailed(ScoveragePlugin.getCHECK_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getAGGREGATE_NAME());
+
+        assertReportFilesExist();
+        assertCoverage(50.0);
+    }
+
+
+    @Test
+    public void checkScoverageFails() throws Exception {
+
+        AssertableBuildResult result = runAndFail("clean", ScoveragePlugin.getCHECK_NAME(),
+                "intTest", "--tests", "org.hello.TestNothingSuite",
+                "-x", "test");
+
+        result.assertTaskSucceeded(ScoveragePlugin.getCOMPILE_NAME());
+        result.assertTaskSucceeded(ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskFailed(ScoveragePlugin.getCHECK_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getAGGREGATE_NAME());
+
+        assertReportFilesExist();
+        assertCoverage(0.0);
+    }
+
+    @Test
+    public void reportScoverageWithExcludedClasses() throws Exception {
+
+        AssertableBuildResult result = run("clean", "-PexcludedFile=.*", ScoveragePlugin.getREPORT_NAME());
+
+        result.assertTaskSucceeded(ScoveragePlugin.getCOMPILE_NAME());
+        result.assertTaskSucceeded(ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getCHECK_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getAGGREGATE_NAME());
+
+        Assert.assertTrue(resolve(reportDir(), "index.html").exists());
+        Assert.assertFalse(resolve(reportDir(), "src/main/scala/org/hello/World.scala.html").exists());
+        assertCoverage(100.0); // coverage is 100 since no classes are covered
+
+        // compiled class should exist in the default classes directory, but not in scoverage
+        Assert.assertTrue(resolve(buildDir(), "classes/scala/main/org/hello/World.class").exists());
+        Assert.assertFalse(resolve(buildDir(), "classes/scala/scoverage/org/hello/World.class").exists());
+    }
+
+    @Test
+    public void reportScoverageWithoutNormalCompilation() throws Exception {
+
+        AssertableBuildResult result = run("clean", ScoveragePlugin.getREPORT_NAME(),
+                "-x", "compileScala");
+
+        result.assertTaskSkipped("compileScala");
+        result.assertTaskSucceeded(ScoveragePlugin.getCOMPILE_NAME());
+        result.assertTaskSucceeded(ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getCHECK_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getAGGREGATE_NAME());
+
+        assertReportFilesExist();
+        assertCoverage(100.0);
+
+        Assert.assertTrue(resolve(buildDir(), "classes/scala/main/org/hello/World.class").exists());
+        Assert.assertFalse(resolve(buildDir(), "classes/scala/scoverage/org/hello/World.class").exists());
+    }
+
+    @Test
+    public void reportScoverageWithoutNormalCompilationAndWithExcludedClasses() throws Exception {
+
+        AssertableBuildResult result = run("clean", ScoveragePlugin.getREPORT_NAME(),
+                "-PexcludedFile=.*", "-x", "compileScala");
+
+        Assert.assertTrue(resolve(reportDir(), "index.html").exists());
+        Assert.assertFalse(resolve(reportDir(), "src/main/scala/org/hello/World.scala.html").exists());
+        assertCoverage(100.0); // coverage is 100 since no classes are covered
+
+        // compiled class should exist in the default classes directory, but not in scoverage
+        Assert.assertTrue(resolve(buildDir(), "classes/scala/main/org/hello/World.class").exists());
+        Assert.assertFalse(resolve(buildDir(), "classes/scala/scoverage/org/hello/World.class").exists());
+    }
+
 
     private void assertReportFilesExist() {
 

--- a/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/build.gradle
+++ b/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/build.gradle
@@ -1,0 +1,71 @@
+plugins {
+    id 'io.spring.dependency-management' version "1.0.4.RELEASE"
+    id 'org.scoverage'
+}
+
+repositories {
+    jcenter()
+}
+
+description = 'a single-module Scala project with dependency manager that builds successfully with 100% coverage'
+
+apply plugin: 'scala'
+
+
+dependencyManagement {
+    dependencies {
+        dependency group: 'org.scala-lang', name: 'scala-library', version: "${scalaVersionMajor}.${scalaVersionMinor}.${scalaVersionBuild}"
+    }
+}
+
+dependencies {
+    compile group: 'org.scala-lang', name: 'scala-library'
+
+    // scala compilation with the dependency management plugin needs this (otherwise compilation will fail)
+    zinc group: 'com.typesafe.zinc', name: 'zinc', version: '0.3.15'
+    zinc group: 'org.scala-lang', name: 'scala-library', version: '2.10.5'
+
+    testRuntime group: 'org.junit.vintage', name: 'junit-vintage-engine', version: junitVersion
+    testCompile group: 'org.junit.platform', name: 'junit-platform-runner', version: junitPlatformVersion
+
+    testCompile group: 'org.scalatest', name: "scalatest_${scalaVersionMajor}.${scalaVersionMinor}", version: scalatestVersion
+}
+
+test {
+    useJUnitPlatform()
+}
+
+
+configurations {
+    intTestCompile.extendsFrom testCompile
+    intTestRuntime.extendsFrom testRuntime
+}
+sourceSets {
+    intTest {
+        resources.srcDir file('src/intTest/resources')
+        scala {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+            srcDir file("${projectDir}/src/intTest/scala")
+        }
+    }
+}
+
+test {
+    maxParallelForks = 1
+}
+
+task intTest(type: Test) {
+    testClassesDirs = sourceSets.intTest.output.classesDirs
+    classpath = sourceSets.intTest.runtimeClasspath
+    outputs.upToDateWhen { false }
+
+    maxParallelForks = 1
+}
+check.dependsOn(intTest)
+intTest.mustRunAfter(test)
+
+scoverage {
+    minimumRate = 0.3
+}
+

--- a/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/build.gradle
+++ b/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/build.gradle
@@ -66,6 +66,9 @@ check.dependsOn(intTest)
 intTest.mustRunAfter(test)
 
 scoverage {
-    minimumRate = 0.3
+    minimumRate = 0.6
 }
 
+if (hasProperty("excludedFile")) {
+    scoverage.excludedFiles = [excludedFile]
+}

--- a/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/src/intTest/scala/org/hello/TestNothingSuite.scala
+++ b/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/src/intTest/scala/org/hello/TestNothingSuite.scala
@@ -5,9 +5,8 @@ import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class WorldIntSuite extends FunSuite {
+class TestNothingSuite extends FunSuite {
 
-  test("bar") {
-    new World().bar
+  test("nothing") {
   }
 }

--- a/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/src/intTest/scala/org/hello/WordIntSuite.scala
+++ b/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/src/intTest/scala/org/hello/WordIntSuite.scala
@@ -1,0 +1,13 @@
+package org.hello
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WorldIntSuite extends FunSuite {
+
+  test("bar") {
+    new World().bar
+  }
+}

--- a/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/src/intTest/scala/org/hello/WorldIntSuite.scala
+++ b/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/src/intTest/scala/org/hello/WorldIntSuite.scala
@@ -5,9 +5,9 @@ import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class WorldSuite extends FunSuite {
+class WorldIntSuite extends FunSuite {
 
-  test("foo") {
-    new World().foo()
+  test("bar") {
+    new World().bar()
   }
 }

--- a/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/src/main/scala/org/hello/World.scala
+++ b/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/src/main/scala/org/hello/World.scala
@@ -1,0 +1,11 @@
+package org.hello
+
+class World {
+
+  def foo: String = {
+    val s = "a" + "b"
+    s
+  }
+
+  def bar: String = "bar"
+}

--- a/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/src/main/scala/org/hello/World.scala
+++ b/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/src/main/scala/org/hello/World.scala
@@ -2,10 +2,10 @@ package org.hello
 
 class World {
 
-  def foo: String = {
+  def foo(): String = {
     val s = "a" + "b"
     s
   }
 
-  def bar: String = "bar"
+  def bar(): String = "bar"
 }

--- a/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/src/test/scala/org/hello/WorldSuite.scala
+++ b/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/src/test/scala/org/hello/WorldSuite.scala
@@ -1,0 +1,13 @@
+package org.hello
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WorldSuite extends FunSuite {
+
+  test("foo") {
+    new World().foo
+  }
+}

--- a/src/main/groovy/org/scoverage/OverallCheckTask.groovy
+++ b/src/main/groovy/org/scoverage/OverallCheckTask.groovy
@@ -1,6 +1,5 @@
 package org.scoverage
 
-import org.apache.tools.ant.taskdefs.Local
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.provider.Property
@@ -69,12 +68,12 @@ class OverallCheckTask extends DefaultTask {
 
     @VisibleForTesting
     protected static String errorMsg(String actual, String expected, CoverageType type) {
-        return "Only $actual% of project is covered by tests instead of $expected% (coverageType: $type)"
+        "Only $actual% of project is covered by tests instead of $expected% (coverageType: $type)"
     }
 
     @VisibleForTesting
     protected static String fileNotFoundErrorMsg(CoverageType coverageType) {
-        return "Coverage file (type: $coverageType) not found, check your configuration."
+        "Coverage file (type: $coverageType) not found, check your configuration."
     }
 
     @VisibleForTesting
@@ -100,6 +99,6 @@ class OverallCheckTask extends DefaultTask {
         } catch (FileNotFoundException fnfe) {
             return new GradleException(fileNotFoundErrorMsg(coverageType), fnfe)
         }
-        return null
+        null
     }
 }

--- a/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
+++ b/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
@@ -143,12 +143,16 @@ class ScoveragePlugin implements Plugin<PluginAware> {
             }
 
             globalReportTask.configure {
+                def reportDirs = reportTasks.findResults { it.reportDir.get() }
+
                 dependsOn reportTasks
-                onlyIf { reportTasks.any { it.reportDir.get().list() } }
+                onlyIf { reportDirs.any { it.list() } }
+
                 group = 'verification'
                 runner = scoverageRunner
                 reportDir = extension.reportDir
-                deleteReportsOnAggregation = extension.deleteReportsOnAggregation
+                dirsToAggregateFrom = reportDirs
+                deleteReportsOnAggregation = false
                 coverageOutputCobertura = extension.coverageOutputCobertura
                 coverageOutputXML = extension.coverageOutputXML
                 coverageOutputHTML = extension.coverageOutputHTML

--- a/src/main/groovy/org/scoverage/ScoverageReport.groovy
+++ b/src/main/groovy/org/scoverage/ScoverageReport.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import scala.collection.JavaConverters
 import scala.collection.Seq
 import scala.collection.Set
 import scoverage.Coverage
@@ -46,8 +47,7 @@ class ScoverageReport extends DefaultTask {
                 project.logger.info("[scoverage] Could not find coverage file, skipping...")
             } else {
                 File[] array = IOUtils.findMeasurementFiles(dataDir.get())
-                // TODO: patch scoverage core to use a consistent collection type?
-                Seq<File> measurementFiles = scala.collection.JavaConversions.asScalaBuffer(Arrays.asList(array))
+                Seq<File> measurementFiles = JavaConverters.asScalaBuffer(Arrays.asList(array))
 
                 Coverage coverage = Serializer.deserialize(coverageFile)
 


### PR DESCRIPTION
Hi guys,

Thanks for a wonderful plugin!

I managed to implement gathering of scoverage results for both test and integrationTest (custom task) in the previous version of the plugin (2.x.x).

The new version of the plugin breaks my last hack and requires a new hack to be implemented in order to migrate to newest version 😄 
I don't know if it's a major problem but usually projects have not just one Test task, an example would be this plugin itself where we have test and functionalTest sourceSets and their respective tasks.

This implementation that I did has one problem I noticed so far - one of the tests fails (but that might be not an issue, just a bit different behaviour).

My problem is that I can't migrate to the new version of the plugin because I can't add my custom test tasks to scoverage reporting.

Do you mind please to have a look and tell me if I miss something of if there's a way to do what I need.
If you think this code make sense, please feel free to change it if you think there's something to be improved.