### PR TITLE
Issue #102: Honor java sources when running compileScoverageScala

### DIFF
--- a/src/functionalTest/resources/projects/scala-single-multi-lang-module/build.gradle
+++ b/src/functionalTest/resources/projects/scala-single-multi-lang-module/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'org.scoverage'
+}
+
+repositories {
+    jcenter()
+}
+
+description = 'a single-module Scala project with java and scala sources'
+
+apply plugin: 'java'
+apply plugin: 'scala'
+
+dependencies {
+    compile group: 'org.scala-lang', name: 'scala-library', version: "${scalaVersionMajor}.${scalaVersionMinor}.${scalaVersionBuild}"
+
+    testRuntime group: 'org.junit.vintage', name: 'junit-vintage-engine', version: junitVersion
+    testCompile group: 'org.junit.platform', name: 'junit-platform-runner', version: junitPlatformVersion
+
+    testCompile group: 'org.scalatest', name: "scalatest_${scalaVersionMajor}.${scalaVersionMinor}", version: scalatestVersion
+}
+
+test {
+    useJUnitPlatform()
+}
+
+scoverage {
+    minimumRate = 0.3
+}
+
+if (hasProperty("excludedFile")) {
+    scoverage.excludedFiles = [excludedFile]
+}

--- a/src/functionalTest/resources/projects/scala-single-multi-lang-module/src/main/java/org/hello/JavaWorld.java
+++ b/src/functionalTest/resources/projects/scala-single-multi-lang-module/src/main/java/org/hello/JavaWorld.java
@@ -1,0 +1,7 @@
+package org.hello;
+
+public class JavaWorld {
+    public static void hello() {
+        System.out.println("Hello, World!");
+    }
+}

--- a/src/functionalTest/resources/projects/scala-single-multi-lang-module/src/main/scala/org/hello/World.scala
+++ b/src/functionalTest/resources/projects/scala-single-multi-lang-module/src/main/scala/org/hello/World.scala
@@ -1,0 +1,14 @@
+package org.hello
+
+class World {
+
+  def foo(): String = {
+    val s = "a" + "b"
+    s
+  }
+
+  // not covered by tests
+  def bar(): String = "y"
+
+  def helloFromJava(): Unit = JavaWorld.hello()
+}

--- a/src/functionalTest/resources/projects/scala-single-multi-lang-module/src/test/scala/org/hello/TestNothingSuite.scala
+++ b/src/functionalTest/resources/projects/scala-single-multi-lang-module/src/test/scala/org/hello/TestNothingSuite.scala
@@ -1,0 +1,12 @@
+package org.hello
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TestNothingSuite extends FunSuite {
+
+  test("nothing") {
+  }
+}

--- a/src/functionalTest/resources/projects/scala-single-multi-lang-module/src/test/scala/org/hello/WorldSuite.scala
+++ b/src/functionalTest/resources/projects/scala-single-multi-lang-module/src/test/scala/org/hello/WorldSuite.scala
@@ -1,0 +1,17 @@
+package org.hello
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WorldSuite extends FunSuite {
+
+  test("foo") {
+    new World().foo()
+  }
+
+  test("helloFromJava") {
+    new World().helloFromJava()
+  }
+}

--- a/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
+++ b/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
@@ -106,6 +106,7 @@ class ScoveragePlugin implements Plugin<PluginAware> {
         def instrumentedSourceSet = project.sourceSets.create('scoverage') {
 
             resources.source(originalSourceSet.resources)
+            java.source(originalSourceSet.java)
             scala.source(originalSourceSet.scala)
 
             compileClasspath += originalSourceSet.compileClasspath + project.configurations.scoverage


### PR DESCRIPTION
Adds java sources to scoverage source set so that compilation doesn't fail during reporting scoverage results