### PR TITLE
Mention the individual tasks that are automatically created.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ You can find instructions on how to apply the plugin at:  http://plugins.gradle.
 
 1. `reportScoverage`: Produces XML and HTML reports for analysing test code coverage.
 
+    The plugin automatically creates a `report{Task name}Scoverage` task for each test task in your
+    Gradle build.  The `reportScoverage` task will run all test tasks and you can use the individual
+    tasks to run only the desired tests.  For example, to run only the unit tests and no other test
+    tasks (e.g., integration tests), you can run `reportTestScoverage`.
+
 2. `aggregateScoverage`: An experimental support for aggregating coverage statistics in composite builds.
 
     When applied on a project with sub-projects, the plugin will create the aggregation task `aggregateScoverage`, which


### PR DESCRIPTION
Running the `reportScoverage` task runs all the test tasks, regardless of what task you're passing on the command line.

I was able to use `reportTestScoverage` to only run the unit tests.

So instead of:
```
./gradlew test reportScoverage -x integrationTest
```
I was able to do:
```
./gradlew test reportTestScoverage
```