### PR TITLE
Issue #102: Use deprecated JavaConversions to maintain backward compatibility with Scala 2.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ task functionalTest(type: Test) {
     group = 'verification'
     testClassesDirs = sourceSets.functionalTest.output.classesDirs
     classpath = sourceSets.functionalTest.runtimeClasspath
+
+    testLogging.showStandardStreams = true
+
     mustRunAfter test
 }
 

--- a/src/main/groovy/org/scoverage/ScoverageAggregate.groovy
+++ b/src/main/groovy/org/scoverage/ScoverageAggregate.groovy
@@ -6,7 +6,8 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import scala.collection.JavaConverters
+// don't use scala.collection.JavaConverters as it breaks backward compatibility with scala 2.11
+import scala.collection.JavaConversions
 import scoverage.IOUtils
 import scoverage.report.CoverageAggregator
 
@@ -47,9 +48,9 @@ class ScoverageAggregate extends DefaultTask {
                 coverage = CoverageAggregator.aggregate(rootDir, deleteReportsOnAggregation.get())
             } else {
                 def reportFiles = dirsToAggregateFrom.get().collectMany {
-                    JavaConverters.seqAsJavaList(IOUtils.reportFileSearch(it, IOUtils.isReportFile()))
+                    JavaConversions.seqAsJavaList(IOUtils.reportFileSearch(it, IOUtils.isReportFile()))
                 }
-                coverage = CoverageAggregator.aggregate(JavaConverters.asScalaBuffer(reportFiles), deleteReportsOnAggregation.get())
+                coverage = CoverageAggregator.aggregate(JavaConversions.asScalaBuffer(reportFiles), deleteReportsOnAggregation.get())
             }
 
             reportDir.get().deleteDir()

--- a/src/main/groovy/org/scoverage/ScoverageReport.groovy
+++ b/src/main/groovy/org/scoverage/ScoverageReport.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+// don't use scala.collection.JavaConverters as it breaks backward compatibility with scala 2.11
 import scala.collection.JavaConversions
 import scala.collection.Seq
 import scala.collection.Set


### PR DESCRIPTION
JavaConversions is still in Scala 2.13, so we're safe to use it.
Tested by running functional tests with 2.11 version of Scala.

Should also fix #94