### PR TITLE
Fix #112 - specific module in multi module project without normal compilation

### DIFF
--- a/src/functionalTest/java/org.scoverage/ScalaMultiModuleTest.java
+++ b/src/functionalTest/java/org.scoverage/ScalaMultiModuleTest.java
@@ -36,12 +36,38 @@ public class ScalaMultiModuleTest extends ScoverageFunctionalTest {
     @Test
     public void reportScoverageOnlyA() {
 
-        AssertableBuildResult result = dryRun("clean", ":a:" + ScoveragePlugin.getREPORT_NAME());
+        AssertableBuildResult result = run("clean", ":a:" + ScoveragePlugin.getREPORT_NAME());
 
         result.assertTaskDoesntExist(ScoveragePlugin.getREPORT_NAME());
-        result.assertTaskExists("a:" + ScoveragePlugin.getREPORT_NAME());
         result.assertTaskDoesntExist("b:" + ScoveragePlugin.getREPORT_NAME());
         result.assertTaskDoesntExist("common:" + ScoveragePlugin.getREPORT_NAME());
+
+        result.assertTaskSucceeded("a:" + ScoveragePlugin.getCOMPILE_NAME());
+        result.assertTaskSucceeded("a:" + ScoveragePlugin.getREPORT_NAME());
+
+        assertAReportFilesExist();
+    }
+
+    @Test
+    public void reportScoverageOnlyAWithoutNormalCompilation() {
+
+        AssertableBuildResult result = run("clean", ":a:" + ScoveragePlugin.getREPORT_NAME(),
+                "-x", "compileScala");
+
+        result.assertTaskSkipped("compileScala");
+        result.assertTaskSkipped("a:compileScala");
+        result.assertTaskSkipped("common:compileScala");
+        result.assertTaskSucceeded("common:" + ScoveragePlugin.getCOMPILE_NAME());
+        result.assertTaskSucceeded("a:" + ScoveragePlugin.getCOMPILE_NAME());
+        result.assertTaskSucceeded("a:" + ScoveragePlugin.getREPORT_NAME());
+
+        assertAReportFilesExist();
+
+        Assert.assertTrue(resolve(buildDir(resolve(projectDir(), "a")), "classes/scala/main/org/hello/a/WorldA.class").exists());
+        Assert.assertFalse(resolve(buildDir(resolve(projectDir(), "a")), "classes/scala/scoverage/org/hello/a/WorldA.class").exists());
+
+        Assert.assertTrue(resolve(buildDir(resolve(projectDir(), "common")), "classes/scala/main/org/hello/common/WorldCommon.class").exists());
+        Assert.assertFalse(resolve(buildDir(resolve(projectDir(), "common")), "classes/scala/scoverage/org/hello/common/WorldCommon.class").exists());
     }
 
     @Test

--- a/src/functionalTest/java/org.scoverage/ScalaSingleModuleTest.java
+++ b/src/functionalTest/java/org.scoverage/ScalaSingleModuleTest.java
@@ -133,15 +133,6 @@ public class ScalaSingleModuleTest extends ScoverageFunctionalTest {
         Assert.assertFalse(resolve(buildDir(), "classes/scala/scoverage/org/hello/World.class").exists());
     }
 
-    @Test
-    public void reportScoverageUnder2_11() throws Exception {
-        run("clean", ScoveragePlugin.getREPORT_NAME(),
-                "-PscalaVersionMinor=11",
-                "-PscalaVersionBuild=8",
-                "-Pscoverage.scoverageScalaVersion=2_11");
-        assertReportFilesExist();
-    }
-
     private void assertReportFilesExist() {
 
         Assert.assertTrue(resolve(reportDir(), "index.html").exists());

--- a/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
+++ b/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
@@ -266,51 +266,53 @@ class ScoveragePlugin implements Plugin<PluginAware> {
                             }
                         }
                     }
+                }
 
-                    compileTask.configure {
-                        if (!graph.hasTask(originalCompileTask)) {
-                            destinationDir = originalCompileTask.destinationDir
-                        } else {
-                            doFirst {
-                                destinationDir.deleteDir()
-                            }
+                compileTask.configure {
+                    if (!graph.hasTask(originalCompileTask)) {
+                        project.logger.info("Making scoverage compilation the primary compilation task (instead of compileScala)")
+                        destinationDir = originalCompileTask.destinationDir
+                    } else {
+                        doFirst {
+                            destinationDir.deleteDir()
+                        }
 
-                            // delete non-instrumented classes by comparing normally compiled classes to those compiled with scoverage
-                            doLast {
-                                def originalCompileTaskName = project.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-                                        .getCompileTaskName("scala")
-                                def originalDestinationDir = project.tasks[originalCompileTaskName].destinationDir
+                        // delete non-instrumented classes by comparing normally compiled classes to those compiled with scoverage
+                        doLast {
+                            project.logger.info("Deleting classes compiled by scoverage but non-instrumented (identical to normal compilation)")
+                            def originalCompileTaskName = project.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+                                    .getCompileTaskName("scala")
+                            def originalDestinationDir = project.tasks[originalCompileTaskName].destinationDir
 
-                                def findFiles = { File dir, Closure<Boolean> condition = null ->
-                                    def files = []
+                            def findFiles = { File dir, Closure<Boolean> condition = null ->
+                                def files = []
 
-                                    if (dir.exists()) {
-                                        dir.eachFileRecurse(FILES) { f ->
-                                            if (condition == null || condition(f)) {
-                                                def relativePath = dir.relativePath(f)
-                                                files << relativePath
-                                            }
+                                if (dir.exists()) {
+                                    dir.eachFileRecurse(FILES) { f ->
+                                        if (condition == null || condition(f)) {
+                                            def relativePath = dir.relativePath(f)
+                                            files << relativePath
                                         }
                                     }
-
-                                    files
                                 }
 
-                                def isSameFile = { String relativePath ->
-                                    def fileA = new File(originalDestinationDir, relativePath)
-                                    def fileB = new File(destinationDir, relativePath)
-                                    FileUtils.contentEquals(fileA, fileB)
-                                }
+                                files
+                            }
 
-                                def originalClasses = findFiles(originalDestinationDir)
-                                def identicalInstrumentedClasses = findFiles(destinationDir, { f ->
-                                    def relativePath = destinationDir.relativePath(f)
-                                    originalClasses.contains(relativePath) && isSameFile(relativePath)
-                                })
+                            def isSameFile = { String relativePath ->
+                                def fileA = new File(originalDestinationDir, relativePath)
+                                def fileB = new File(destinationDir, relativePath)
+                                FileUtils.contentEquals(fileA, fileB)
+                            }
 
-                                identicalInstrumentedClasses.each { f ->
-                                    Files.deleteIfExists(destinationDir.toPath().resolve(f))
-                                }
+                            def originalClasses = findFiles(originalDestinationDir)
+                            def identicalInstrumentedClasses = findFiles(destinationDir, { f ->
+                                def relativePath = destinationDir.relativePath(f)
+                                originalClasses.contains(relativePath) && isSameFile(relativePath)
+                            })
+
+                            identicalInstrumentedClasses.each { f ->
+                                Files.deleteIfExists(destinationDir.toPath().resolve(f))
                             }
                         }
                     }


### PR DESCRIPTION
Fixes #112.

Note that some functional tests fail in the clean task non-deterministically in IntelliJ on Windows 10 due to file lock issues.