### PR TITLE
Add (ignored) tests for composite builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ You can find instructions on how to apply the plugin at http://plugins.gradle.or
 
     `gradle checkScoverage` will automatically invoke `reportScoverage` but it won't generate aggregated reports.
     In order to check coverage of aggregated reports one should use `gradle checkScoverage aggregateScoverage`.
+
+**Note:** The plugin is not compatible with composite builds. For more information, see [the relevant issue](https://github.com/scoverage/gradle-scoverage/issues/98).
     
 ### Configuration
 

--- a/src/functionalTest/java/org.scoverage/CompositeBuildTest.java
+++ b/src/functionalTest/java/org.scoverage/CompositeBuildTest.java
@@ -1,0 +1,46 @@
+package org.scoverage;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tests are currently ignored as composite builds are not supported yet.
+ *
+ * See https://github.com/scoverage/gradle-scoverage/issues/98
+ */
+public class CompositeBuildTest extends ScoverageFunctionalTest {
+
+    public CompositeBuildTest() {
+        super("composite-build");
+    }
+
+    @Ignore
+    @Test
+    public void buildComposite() {
+
+        runComposite("clean", "build");
+    }
+
+    @Ignore
+    @Test
+    public void reportComposite() {
+
+        runComposite("clean", ScoveragePlugin.getREPORT_NAME());
+    }
+
+    private AssertableBuildResult runComposite(String... arguments) {
+
+        List<String> fullArguments = new ArrayList<String>();
+        fullArguments.add("-p");
+        fullArguments.add("proj1");
+        fullArguments.add("--include-build");
+        fullArguments.add("../proj2");
+        fullArguments.addAll(Arrays.asList(arguments));
+
+        return run(fullArguments.toArray(new String[0]));
+    }
+}

--- a/src/functionalTest/resources/projects/composite-build/proj1/build.gradle
+++ b/src/functionalTest/resources/projects/composite-build/proj1/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+	id 'org.scoverage'
+}
+
+repositories {
+	jcenter()
+}
+
+description = 'a single-module Scala project taking part in a composite build (1)'
+
+apply plugin: 'java'
+apply plugin: 'scala'
+
+
+group "org.composite"
+version '1.0'
+
+dependencies {
+	compile group: 'org.scala-lang', name: 'scala-library', version: "${scalaVersionMajor}.${scalaVersionMinor}.${scalaVersionBuild}"
+
+	testRuntime group: 'org.junit.vintage', name: 'junit-vintage-engine', version: junitVersion
+	testCompile group: 'org.junit.platform', name: 'junit-platform-runner', version: junitPlatformVersion
+
+	testCompile group: 'org.scalatest', name: "scalatest_${scalaVersionMajor}.${scalaVersionMinor}", version: scalatestVersion
+
+    compile "org.composite:proj2:1.0"
+}
+
+test {
+	useJUnitPlatform()
+}
+

--- a/src/functionalTest/resources/projects/composite-build/proj1/src/main/scala/org/composite/proj1/Foo.scala
+++ b/src/functionalTest/resources/projects/composite-build/proj1/src/main/scala/org/composite/proj1/Foo.scala
@@ -1,0 +1,7 @@
+package org.composite.proj1
+
+import org.composite.proj2.Reporter
+
+class Foo {
+  def bar(): String = "bar"
+}

--- a/src/functionalTest/resources/projects/composite-build/proj1/src/test/scala/org/composite/proj1/FooSuite.scala
+++ b/src/functionalTest/resources/projects/composite-build/proj1/src/test/scala/org/composite/proj1/FooSuite.scala
@@ -1,0 +1,14 @@
+package org.composite.proj1
+
+import org.scalatest.FunSuite
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class FooSuite extends FunSuite {
+
+  test("bar"){
+
+    new Foo().bar()
+  }
+}

--- a/src/functionalTest/resources/projects/composite-build/proj2/build.gradle
+++ b/src/functionalTest/resources/projects/composite-build/proj2/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+	id 'org.scoverage'
+}
+
+repositories {
+	jcenter()
+}
+
+description = 'a single-module Scala project taking part in a composite build (2)'
+
+apply plugin: 'java'
+apply plugin: 'scala'
+
+
+group "org.composite"
+version '1.0'
+
+dependencies {
+	compile group: 'org.scala-lang', name: 'scala-library', version: "${scalaVersionMajor}.${scalaVersionMinor}.${scalaVersionBuild}"
+
+	testRuntime group: 'org.junit.vintage', name: 'junit-vintage-engine', version: junitVersion
+	testCompile group: 'org.junit.platform', name: 'junit-platform-runner', version: junitPlatformVersion
+
+	testCompile group: 'org.scalatest', name: "scalatest_${scalaVersionMajor}.${scalaVersionMinor}", version: scalatestVersion
+}
+
+test {
+	useJUnitPlatform()
+}
+

--- a/src/functionalTest/resources/projects/composite-build/proj2/src/main/scala/org/composite/proj2/Reporter.scala
+++ b/src/functionalTest/resources/projects/composite-build/proj2/src/main/scala/org/composite/proj2/Reporter.scala
@@ -1,0 +1,19 @@
+package org.composite.proj2
+
+class Reporter {
+
+  def report(rawData: String): Report = {
+    Report(1,2)
+  }
+
+  class InnerReporter {
+
+    def lala(): Unit = {
+
+      val x = 1 + 1
+      x
+    }
+  }
+}
+
+case class Report(id: Long, count: Int)

--- a/src/functionalTest/resources/projects/composite-build/proj2/src/test/scala/org/composite/proj2/ReporterSuite.scala
+++ b/src/functionalTest/resources/projects/composite-build/proj2/src/test/scala/org/composite/proj2/ReporterSuite.scala
@@ -1,0 +1,16 @@
+package org.composite.proj2
+
+import org.scalatest.FunSuite
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ReporterSuite extends FunSuite {
+
+  test("report"){
+
+    val report = new Reporter().report("x")
+
+    assertResult(Report(1, 2))(report)
+  }
+}


### PR DESCRIPTION
This PR merely adds tests for composite builds, but does not add support for them (so it **doesn't** fix the issue #98).

I believe there is currently a bug with Gradle's composite build regarding `mustRunAfter` functionality with cross-build tasks (https://github.com/gradle/gradle/issues/11747). The error in #98 is caused by [this line](https://github.com/scoverage/gradle-scoverage/blob/c5870c9b924bb5c46c343c2732f65bfde37aa562/src/main/groovy/org/scoverage/ScoveragePlugin.groovy#L170).

I'm also seeing mentions of incorrect handling of composite build dependencies in [this thread on the Gradle forums](https://discuss.gradle.org/t/how-to-order-a-composite-build-with-dependson/).