### PR TITLE
Fix: ScoverageReport task inputs declaration

### DIFF
--- a/src/main/groovy/org/scoverage/ScoverageReport.groovy
+++ b/src/main/groovy/org/scoverage/ScoverageReport.groovy
@@ -4,10 +4,14 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.TaskAction
 import scoverage.report.CoverageAggregator
+
+import static org.gradle.api.tasks.PathSensitivity.RELATIVE
 
 @CacheableTask
 class ScoverageReport extends DefaultTask {
@@ -15,10 +19,12 @@ class ScoverageReport extends DefaultTask {
     @Nested
     ScoverageRunner runner
 
-    @Input
+    @InputDirectory
+    @PathSensitive(RELATIVE)
     final Property<File> dataDir = project.objects.property(File)
 
-    @Input
+    @InputDirectory
+    @PathSensitive(RELATIVE)
     final Property<File> sources = project.objects.property(File)
 
     @OutputDirectory


### PR DESCRIPTION
As you can see [in Gradle documentation](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:task_input_output_annotations) an input of type File shouldn't be annotated as `@Input`, in this case they are directories, so `@InputDirectory` seems more appropriate, and using Relative path sensitivity you allow it to be relocatable (so, for example shared between 2 different users, or CI and a dev).

I found that because a project had a report showing a class that was deleted, just the class, inside a file with more classes, and if you look on the [`@InputDirectory` documentation](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/InputDirectory.html) it will make clear why:

> Note: To make the task dependent on the directory's location but not its contents, expose the path of the directory as an Input property instead.

 