### PR TITLE
Add support for Scala 2.13

### DIFF
--- a/src/crossScalaVersionTest/java/org/scoverage/Scala213Test.java
+++ b/src/crossScalaVersionTest/java/org/scoverage/Scala213Test.java
@@ -1,13 +1,5 @@
 package org.scoverage;
 
-import org.junit.Ignore;
-
-/**
- * Tests is currently ignored as support for Scala 2.13 is not available yet.
- *
- * @see <a href="https://github.com/scoverage/gradle-scoverage/issues/106">Issue #106</a>.
- */
-@Ignore
 public class Scala213Test extends ScalaVersionTest {
     public Scala213Test() {
         super("2_13");

--- a/src/main/groovy/org/scoverage/ScoverageWriter.java
+++ b/src/main/groovy/org/scoverage/ScoverageWriter.java
@@ -2,8 +2,6 @@ package org.scoverage;
 
 import org.gradle.api.logging.Logger;
 import scala.Some;
-import scala.collection.JavaConverters;
-import scala.collection.mutable.Buffer;
 import scoverage.Constants;
 import scoverage.Coverage;
 import scoverage.report.CoberturaXmlWriter;
@@ -11,7 +9,7 @@ import scoverage.report.ScoverageHtmlWriter;
 import scoverage.report.ScoverageXmlWriter;
 
 import java.io.File;
-import java.util.Arrays;
+import java.lang.reflect.Field;
 
 /**
  * Util for generating and saving coverage files.
@@ -46,7 +44,7 @@ public class ScoverageWriter {
                              Boolean coverageOutputCobertura,
                              Boolean coverageOutputXML,
                              Boolean coverageOutputHTML,
-                             Boolean coverageDebug) {
+                             Boolean coverageDebug) throws NoSuchFieldException, IllegalAccessException {
 
         logger.info("[scoverage] Generating scoverage reports...");
 
@@ -76,8 +74,11 @@ public class ScoverageWriter {
         }
 
         if (coverageOutputHTML) {
-            Buffer<File> sources = JavaConverters.asScalaBufferConverter(Arrays.asList(sourceDir)).asScala();
-            new ScoverageHtmlWriter(sources, reportDir, new Some<>(sourceEncoding)).write(coverage);
+            ScoverageHtmlWriter writer = new ScoverageHtmlWriter(sourceDir, reportDir);
+            Field field = ScoverageHtmlWriter.class.getDeclaredField("sourceEncoding");
+            field.setAccessible(true);
+            field.set(writer, new Some<>(sourceEncoding));
+            writer.write(coverage);
             logger.info("[scoverage] Written HTML report to " +
                 reportDir.getAbsolutePath() +
                 File.separator +


### PR DESCRIPTION
This fix may look a bit "hacky" because it uses reflection to be able to set the correct `sourceEncoding` (BTW it seems there's no test covering that), but it may be worth it in the short-term until we see some movement in scalac-scoverage-plugin, as it has been almost one year without any releases there, and Scala 2.13 came out well over a year now.

This is the only solution I think of that can work with the current scalac-scoverage-plugin without requiring cross-building on gradle-scoverage side. The other constructors in ScoverageHtmlWriter use scala.Seq which is effectively a different type in Scala 2.12 and 2.13, so only cross-building could get over it.

Fixes #106 