### PR TITLE
Fix CoverageFileName

### DIFF
--- a/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
+++ b/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
@@ -191,7 +191,7 @@ class ScoveragePlugin implements Plugin<PluginAware> {
                 }
                 scalaCompileOptions.additionalParameters = parameters
                 // the compile task creates a store of measured statements
-                outputs.file(new File(extension.dataDir.get(), 'scoverage.coverage.xml'))
+                outputs.file(new File(extension.dataDir.get(), 'scoverage.coverage'))
 
                 dependsOn project.configurations[CONFIGURATION_NAME]
                 doFirst {


### PR DESCRIPTION
fixes #135 

This issue is making builds using the Gradle BuildCache to report 0% coverage.
Gradle caches the .xml file that doesn't exist from the compile task and then the report task doesn't see anything, now it will cache the right file fixing the builds.