### PR TITLE
Use Scala full version in plugin and binary version in runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can find instructions on how to apply the plugin at http://plugins.gradle.or
 The plugin exposes multiple options that can be configured by setting them in an `scoverage` block within the project's
 build script. These options are as follows:
 
-* `scoverageVersion = <String>` (default `"1.4.2`): The version of the scoverage scalac plugin. This (gradle) plugin
+* `scoverageVersion = <String>` (default `"1.4.8`): The version of the scoverage scalac plugin. This (gradle) plugin
 should be compatible with all 1+ versions.
 
 * `scoverageScalaVersion = <String>` (default `detected`): The scala version of the scoverage scalac plugin. This

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.5.2'
 
-    testImplementation 'org.hamcrest:hamcrest-library:1.3'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
 }
 
 sourceSets {

--- a/src/functionalTest/java/org/scoverage/DetectScalaLibraryTest.java
+++ b/src/functionalTest/java/org/scoverage/DetectScalaLibraryTest.java
@@ -1,24 +1,22 @@
 package org.scoverage;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.stringContainsInOrder;
 
 @RunWith(Parameterized.class)
 public class DetectScalaLibraryTest extends ScoverageFunctionalTest {
 
-    private static final String SCALA_VERSION = "2.12";
+    private static final String SCALA_VERSION = "2.13";
     private static final String SCALA_LIBRARY_PARAMETER = "-PdetectedScalaLibraryVersion=";
-
-    private static final String EXPECTED_OUTPUT_CONFIGURED_VERSION = "Using configured Scala version";
-    private static final String EXPECTED_OUTPUT_DETECTED_VERSION = "Detected scala library in compilation classpath";
-    private static final String EXPECTED_OUTPUT_USING = "Using scoverage scalac plugin version '" + SCALA_VERSION;
 
     @Parameterized.Parameter(0)
     public String projectDir;
@@ -56,7 +54,7 @@ public class DetectScalaLibraryTest extends ScoverageFunctionalTest {
         }
     }
 
-    private void testWithParameter(String parameter, Boolean detect) {
+    private void testWithParameter(String parameter, boolean detect) {
 
         String[] basicParameters = {"clean", parameter, "--info"};
         String[] parameters = Stream.concat(Arrays.stream(basicParameters), Arrays.stream(additionalParameters))
@@ -65,11 +63,11 @@ public class DetectScalaLibraryTest extends ScoverageFunctionalTest {
 
         String output = result.getResult().getOutput();
         if (detect) {
-            Assert.assertTrue(output.contains(EXPECTED_OUTPUT_DETECTED_VERSION));
+            assertThat(output, containsString("Detected scala library in compilation classpath"));
         } else {
-            Assert.assertTrue(output.contains(EXPECTED_OUTPUT_CONFIGURED_VERSION));
+            assertThat(output, containsString("Using configured Scala version"));
         }
-        Assert.assertTrue(output.contains(EXPECTED_OUTPUT_USING));
+        assertThat(output, stringContainsInOrder("Using scoverage scalac plugin", "for scala", SCALA_VERSION));
     }
 
 }

--- a/src/main/groovy/org/scoverage/ScoverageExtension.groovy
+++ b/src/main/groovy/org/scoverage/ScoverageExtension.groovy
@@ -57,7 +57,7 @@ class ScoverageExtension {
         project.plugins.apply(ScalaPlugin.class)
 
         scoverageVersion = project.objects.property(String)
-        scoverageVersion.set('1.4.2')
+        scoverageVersion.set('1.4.8')
 
         scoverageScalaVersion = project.objects.property(String)
 

--- a/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
+++ b/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
@@ -24,7 +24,7 @@ class ScoveragePlugin implements Plugin<PluginAware> {
     static final String CHECK_NAME = 'checkScoverage'
     static final String COMPILE_NAME = 'compileScoverageScala'
     static final String AGGREGATE_NAME = 'aggregateScoverage'
-    static final String DEFAULT_SCALA_VERSION = '2.12'
+    static final String DEFAULT_SCALA_VERSION = '2.13.6'
 
     static final String DEFAULT_REPORT_DIR = 'reports' + File.separatorChar + 'scoverage'
 
@@ -60,15 +60,15 @@ class ScoveragePlugin implements Plugin<PluginAware> {
             }
 
             project.afterEvaluate {
-                def scalaVersion = resolveScalaVersion(project)
+                def scalaFullVersion = resolveScalaVersion(project)
+                def scalaBinaryVersion = scalaFullVersion.substring(0, scalaFullVersion.lastIndexOf('.'))
                 def scoverageVersion = project.extensions.scoverage.scoverageVersion.get()
-                def fullScoverageVersion = "$scalaVersion:$scoverageVersion"
 
-                project.logger.info("Using scoverage scalac plugin version '$fullScoverageVersion'")
+                project.logger.info("Using scoverage scalac plugin $scoverageVersion for scala $scalaFullVersion")
 
                 project.dependencies {
-                    scoverage("org.scoverage:scalac-scoverage-plugin_$fullScoverageVersion")
-                    scoverage("org.scoverage:scalac-scoverage-runtime_$fullScoverageVersion")
+                    scoverage("org.scoverage:scalac-scoverage-plugin_$scalaFullVersion:$scoverageVersion")
+                    scoverage("org.scoverage:scalac-scoverage-runtime_$scalaBinaryVersion:$scoverageVersion")
                 }
             }
         }
@@ -360,8 +360,7 @@ class ScoveragePlugin implements Plugin<PluginAware> {
                 it.moduleVersion.group == "org.scala-lang" && it.moduleVersion.name == "scala-library"
             }
             if (scalaLibrary != null) {
-                def fullScalaVersion = scalaLibrary.moduleVersion.version
-                def scalaVersion = fullScalaVersion.substring(0, fullScalaVersion.lastIndexOf("."))
+                def scalaVersion = scalaLibrary.moduleVersion.version
                 project.logger.info("Detected scala library in compilation classpath. Scala version: $scalaVersion")
                 return scalaVersion
             } else {


### PR DESCRIPTION
Since version 1.4.6, scalac-scoverage uses the Scala full version in scalac-scoverage-plugin and the Scala binary version in scalac-scoverage-runtime: https://github.com/scoverage/scalac-scoverage-plugin/releases/tag/v1.4.6

This PR makes the Gradle plugin to correctly detect or read the configured Scala full version and use the full or binary version where appropriate.

Closes #152