### PR TITLE
Support mixed Java/Scala modules using Java annotation processors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 group 'org.scoverage'
 description = 'gradle-scoverage is a Gradle plugin for calculating code coverage using Scoverage'
 if (project.version == 'unspecified') {
-    version = '3.0.0-SNAPSHOT'
+    version = '6.0.0-SNAPSHOT'
 }
 ext {
     website = 'http://scoverage.org'

--- a/src/functionalTest/java/org/scoverage/ScalaJavaAnnotationProcessorTest.java
+++ b/src/functionalTest/java/org/scoverage/ScalaJavaAnnotationProcessorTest.java
@@ -1,0 +1,56 @@
+package org.scoverage;
+
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+public class ScalaJavaAnnotationProcessorTest extends ScoverageFunctionalTest {
+
+    public ScalaJavaAnnotationProcessorTest() {
+        super("scala-java-annotation-processor");
+    }
+
+    @Test
+    public void checkAndAggregateScoverage() throws Exception {
+
+        AssertableBuildResult result = run("clean", ScoveragePlugin.getCHECK_NAME(),
+                ScoveragePlugin.getAGGREGATE_NAME());
+
+        result.assertTaskSkipped("java_only:" + ScoveragePlugin.getCOMPILE_NAME());
+
+        result.assertTaskSkipped(ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskSucceeded("mixed_scala_java:" + ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskSkipped("java_only:" + ScoveragePlugin.getREPORT_NAME());
+
+        result.assertTaskSucceeded(ScoveragePlugin.getCHECK_NAME());
+        result.assertTaskSucceeded("mixed_scala_java:" + ScoveragePlugin.getCHECK_NAME());
+        result.assertTaskSkipped("java_only:" + ScoveragePlugin.getCHECK_NAME());
+
+        result.assertTaskSucceeded(ScoveragePlugin.getAGGREGATE_NAME());
+
+        assertAllReportFilesExist();
+        assertCoverage(100.0);
+    }
+
+    private void assertAllReportFilesExist() {
+
+        Assert.assertTrue(resolve(reportDir(), "index.html").exists());
+
+        assertMixedScalaJavaReportFilesExist();
+        assertAggregationFilesExist();
+    }
+
+    private void assertAggregationFilesExist() {
+
+        Assert.assertTrue(resolve(reportDir(), "mixed_scala_java/src/main/scala/org/hello/WorldScala.scala.html").exists());
+    }
+
+    private void assertMixedScalaJavaReportFilesExist() {
+
+        File reportDir = reportDir(projectDir().toPath().resolve("mixed_scala_java").toFile());
+        Assert.assertTrue(resolve(reportDir, "index.html").exists());
+        Assert.assertTrue(resolve(reportDir, "src/main/scala/org/hello/WorldScala.scala.html").exists());
+    }
+}

--- a/src/functionalTest/resources/projects/scala-java-annotation-processor/build.gradle
+++ b/src/functionalTest/resources/projects/scala-java-annotation-processor/build.gradle
@@ -1,0 +1,50 @@
+plugins {
+    id 'org.scoverage' apply false
+}
+
+description = 'a multi-module Scala and Java project using a Java annotation processor'
+
+allprojects {
+    repositories {
+        jcenter()
+    }
+}
+
+def lombokVersion = '1.18.20'
+
+subprojects {
+    apply plugin: 'java'
+
+    dependencies {
+        testImplementation group: 'org.junit.platform', name: 'junit-platform-runner', version: junitPlatformVersion
+
+        compileOnly "org.projectlombok:lombok:$lombokVersion"
+        annotationProcessor "org.projectlombok:lombok:$lombokVersion"
+
+        testCompileOnly "org.projectlombok:lombok:$lombokVersion"
+        testAnnotationProcessor "org.projectlombok:lombok:$lombokVersion"
+    }
+
+    test {
+        useJUnitPlatform()
+    }
+}
+
+/*
+Because the Scala compiler doesn't support annotation processors, Java files using a Java annotation
+processor MUST be compiled by the Java compiler. So we can't use the same
+configuration as in `scala-java-multi-module` here.
+
+// A common practice in mixed java/scala modules to make Java code able to import Scala code
+ext.configureSources = { set, name ->
+    set.scala.srcDir("src/$name/java")
+    set.java.srcDirs = []
+}
+configureSources(sourceSets.main, 'main')
+configureSources(sourceSets.test, 'test')
+*/
+
+apply plugin: 'org.scoverage'
+scoverage {
+    minimumRate = 0.5
+}

--- a/src/functionalTest/resources/projects/scala-java-annotation-processor/java_only/build.gradle
+++ b/src/functionalTest/resources/projects/scala-java-annotation-processor/java_only/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: junitVersion
+}

--- a/src/functionalTest/resources/projects/scala-java-annotation-processor/java_only/src/main/java/org/hello/WorldJavaOnly.java
+++ b/src/functionalTest/resources/projects/scala-java-annotation-processor/java_only/src/main/java/org/hello/WorldJavaOnly.java
@@ -1,0 +1,8 @@
+package org.hello;
+
+import lombok.Value;
+
+@Value
+public class WorldJavaOnly {
+    private final String foo = "java_only";
+}

--- a/src/functionalTest/resources/projects/scala-java-annotation-processor/java_only/src/test/java/org/hello/WorldJavaOnlyTest.java
+++ b/src/functionalTest/resources/projects/scala-java-annotation-processor/java_only/src/test/java/org/hello/WorldJavaOnlyTest.java
@@ -1,0 +1,11 @@
+package org.hello;
+
+import org.junit.Test;
+
+public class WorldJavaOnlyTest {
+
+    @Test
+    public void foo() {
+        new WorldJavaOnly().foo();
+    }
+}

--- a/src/functionalTest/resources/projects/scala-java-annotation-processor/lombok.config
+++ b/src/functionalTest/resources/projects/scala-java-annotation-processor/lombok.config
@@ -1,0 +1,1 @@
+lombok.accessors.fluent=true

--- a/src/functionalTest/resources/projects/scala-java-annotation-processor/mixed_scala_java/build.gradle
+++ b/src/functionalTest/resources/projects/scala-java-annotation-processor/mixed_scala_java/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'scala'
+
+dependencies {
+    implementation group: 'org.scala-lang', name: 'scala-library', version: "${scalaVersionMajor}.${scalaVersionMinor}.${scalaVersionBuild}"
+
+    testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: junitVersion
+
+    testImplementation group: 'org.scalatest', name: "scalatest_${scalaVersionMajor}.${scalaVersionMinor}", version: scalatestVersion
+}
+
+apply plugin: 'org.scoverage'
+scoverage {
+    minimumRate = 0.5
+}

--- a/src/functionalTest/resources/projects/scala-java-annotation-processor/mixed_scala_java/src/main/java/org/hello/WorldJava.java
+++ b/src/functionalTest/resources/projects/scala-java-annotation-processor/mixed_scala_java/src/main/java/org/hello/WorldJava.java
@@ -1,0 +1,8 @@
+package org.hello;
+
+import lombok.Value;
+
+@Value
+public class WorldJava {
+    private final String foo = "java";
+}

--- a/src/functionalTest/resources/projects/scala-java-annotation-processor/mixed_scala_java/src/main/scala/org/hello/WorldScala.scala
+++ b/src/functionalTest/resources/projects/scala-java-annotation-processor/mixed_scala_java/src/main/scala/org/hello/WorldScala.scala
@@ -1,0 +1,7 @@
+package org.hello
+
+class WorldScala {
+  private val worldJava = new WorldJava()
+
+  def foo() = worldJava.foo()
+}

--- a/src/functionalTest/resources/projects/scala-java-annotation-processor/mixed_scala_java/src/test/java/org/hello/WorldJavaTest.java
+++ b/src/functionalTest/resources/projects/scala-java-annotation-processor/mixed_scala_java/src/test/java/org/hello/WorldJavaTest.java
@@ -1,0 +1,11 @@
+package org.hello;
+
+import org.junit.Test;
+
+public class WorldJavaTest {
+
+    @Test
+    public void foo() {
+        new WorldJava().foo();
+    }
+}

--- a/src/functionalTest/resources/projects/scala-java-annotation-processor/mixed_scala_java/src/test/scala/org/hello/WorldScalaSuite.scala
+++ b/src/functionalTest/resources/projects/scala-java-annotation-processor/mixed_scala_java/src/test/scala/org/hello/WorldScalaSuite.scala
@@ -1,0 +1,13 @@
+package org.hello
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WorldScalaSuite extends FunSuite {
+
+  test("foo") {
+    new WorldScala().foo()
+  }
+}

--- a/src/functionalTest/resources/projects/scala-java-annotation-processor/settings.gradle
+++ b/src/functionalTest/resources/projects/scala-java-annotation-processor/settings.gradle
@@ -1,0 +1,1 @@
+include 'java_only', 'mixed_scala_java'

--- a/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
+++ b/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
@@ -87,6 +87,7 @@ class ScoveragePlugin implements Plugin<PluginAware> {
             java.source(originalSourceSet.java)
             scala.source(originalSourceSet.scala)
 
+            annotationProcessorPath += originalSourceSet.annotationProcessorPath + project.configurations.scoverage
             compileClasspath += originalSourceSet.compileClasspath + project.configurations.scoverage
             runtimeClasspath = it.output + project.configurations.scoverage + originalSourceSet.runtimeClasspath
         }


### PR DESCRIPTION
We use an annotation processor ([lombok](https://projectlombok.org/)) on some Java files in a combined Java/Scala module.

When we tried running scoverage on that module, we noticed that the `compileScoverage*` tasks failed because the annotation processor wasn't being run, even though the non-scoverage `compile*` tasks succeed.

This PR changes the scoverage compile task to inherit the `annotationProcessorPath` from the original compile task, in addition to `compileClasspath` and `runtimeClasspath`.

That fixes the compilation problem we observed.

I'm not sure this is the best solution to this problem, so please let me know if you can think of a better one.