### PR TITLE
Change README from travis-ci.org to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/scoverage/gradle-scoverage.png?branch=master)](https://travis-ci.org/scoverage/gradle-scoverage)
+[![Build Status](https://travis-ci.com/scoverage/gradle-scoverage.png?branch=master)](https://travis-ci.com/scoverage/gradle-scoverage)
 
 gradle-scoverage
 ================


### PR DESCRIPTION
@maiflai [travis-ci.org](https://travis-ci.org/) is no longer running builds. The project needs to be moved to [travis-ci.com](travis-ci.com), which requires admin permissions on the repository/org.

See https://blog.travis-ci.com/2021-05-07-orgshutdown