### PR TITLE
Fix deprecated destinationDir property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,10 @@ task crossScalaVersionTest(type: Test) {
     classpath = sourceSets.crossScalaVersionTest.runtimeClasspath
     forkEvery = 1 // crucial to run every test in its own JVM
 
-    testLogging.showStandardStreams = true
+    testLogging {
+        events 'passed', 'failed', 'skipped'
+        showStandardStreams = System.env.CI == 'true'
+    }
 
     mustRunAfter test
 }
@@ -96,7 +99,10 @@ task functionalTest(type: Test) {
     testClassesDirs = sourceSets.functionalTest.output
     classpath = sourceSets.functionalTest.runtimeClasspath
 
-    testLogging.showStandardStreams = true
+    testLogging {
+        events 'passed', 'failed', 'skipped'
+        showStandardStreams = System.env.CI == 'true'
+    }
 
     mustRunAfter crossScalaVersionTest
 }

--- a/src/crossScalaVersionTest/java/org/scoverage/ScalaCrossVersionAggregationTest.java
+++ b/src/crossScalaVersionTest/java/org/scoverage/ScalaCrossVersionAggregationTest.java
@@ -2,13 +2,6 @@ package org.scoverage;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.jupiter.api.Tag;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.scoverage.ScoverageFunctionalTest;
-import org.scoverage.ScoveragePlugin;
-
-import java.io.File;
 
 public class ScalaCrossVersionAggregationTest extends ScoverageFunctionalTest {
 

--- a/src/functionalTest/java/org/scoverage/CompositeBuildTest.java
+++ b/src/functionalTest/java/org/scoverage/CompositeBuildTest.java
@@ -34,7 +34,7 @@ public class CompositeBuildTest extends ScoverageFunctionalTest {
 
     private AssertableBuildResult runComposite(String... arguments) {
 
-        List<String> fullArguments = new ArrayList<String>();
+        List<String> fullArguments = new ArrayList<>();
         fullArguments.add("-p");
         fullArguments.add("proj1");
         fullArguments.add("--include-build");

--- a/src/functionalTest/java/org/scoverage/ScalaJavaMultiModuleTest.java
+++ b/src/functionalTest/java/org/scoverage/ScalaJavaMultiModuleTest.java
@@ -1,6 +1,5 @@
 package org.scoverage;
 
-import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/functionalTest/java/org/scoverage/ScoverageFunctionalTest.java
+++ b/src/functionalTest/java/org/scoverage/ScoverageFunctionalTest.java
@@ -1,7 +1,7 @@
 package org.scoverage;
 
 import groovy.util.Node;
-import groovy.util.XmlParser;
+import groovy.xml.XmlParser;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
@@ -87,7 +87,7 @@ public abstract class ScoverageFunctionalTest {
 
     protected AssertableBuildResult dryRun(String... arguments) {
 
-        List<String> withDryArgument = new ArrayList<String>(Arrays.asList(arguments));
+        List<String> withDryArgument = new ArrayList<>(Arrays.asList(arguments));
         withDryArgument.add("--dry-run");
         return run(withDryArgument.toArray(new String[]{}));
     }
@@ -119,7 +119,7 @@ public abstract class ScoverageFunctionalTest {
 
     private void configureArguments(String... arguments) {
 
-        List<String> fullArguments = new ArrayList<String>();
+        List<String> fullArguments = new ArrayList<>();
 
         fullArguments.add("-PscalaVersionMajor=2");
         fullArguments.add("-PscalaVersionMinor=12");
@@ -127,6 +127,7 @@ public abstract class ScoverageFunctionalTest {
         fullArguments.add("-PjunitVersion=5.3.2");
         fullArguments.add("-PjunitPlatformVersion=1.3.2");
         fullArguments.add("-PscalatestVersion=3.0.8");
+        fullArguments.add("--warning-mode=all");
         fullArguments.addAll(Arrays.asList(arguments));
 
         runner.withArguments(fullArguments);

--- a/src/main/groovy/org/scoverage/CoverageChecker.groovy
+++ b/src/main/groovy/org/scoverage/CoverageChecker.groovy
@@ -1,6 +1,6 @@
 package org.scoverage
 
-
+import groovy.xml.XmlParser
 import org.gradle.api.GradleException
 import org.gradle.api.logging.Logger
 import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting

--- a/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
+++ b/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
@@ -28,7 +28,7 @@ class ScoveragePlugin implements Plugin<PluginAware> {
 
     static final String DEFAULT_REPORT_DIR = 'reports' + File.separatorChar + 'scoverage'
 
-    private final ConcurrentHashMap<Task, Set<? extends Task>> taskDependencies = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Task, Set<? extends Task>> taskDependencies = new ConcurrentHashMap<>()
 
     @Override
     void apply(PluginAware pluginAware) {
@@ -232,9 +232,10 @@ class ScoveragePlugin implements Plugin<PluginAware> {
                 compileTask.configure {
                     if (!graph.hasTask(originalCompileTask)) {
                         project.logger.info("Making scoverage compilation the primary compilation task (instead of compileScala)")
-                        destinationDir = originalCompileTask.destinationDir
+                        destinationDirectory = originalCompileTask.destinationDirectory
                     } else {
                         doFirst {
+                            def destinationDir = destinationDirectory.get().asFile
                             destinationDir.deleteDir()
                         }
 
@@ -243,7 +244,9 @@ class ScoveragePlugin implements Plugin<PluginAware> {
                             project.logger.info("Deleting classes compiled by scoverage but non-instrumented (identical to normal compilation)")
                             def originalCompileTaskName = project.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
                                     .getCompileTaskName("scala")
-                            def originalDestinationDir = project.tasks[originalCompileTaskName].destinationDir
+                            def originalDestinationDirectory = project.tasks[originalCompileTaskName].destinationDirectory
+                            def originalDestinationDir = originalDestinationDirectory.get().asFile
+                            def destinationDir = destinationDirectory.get().asFile
 
                             def findFiles = { File dir, Closure<Boolean> condition = null ->
                                 def files = []

--- a/src/main/groovy/org/scoverage/ScoverageRunner.groovy
+++ b/src/main/groovy/org/scoverage/ScoverageRunner.groovy
@@ -23,7 +23,7 @@ class ScoverageRunner {
         method.setAccessible(true)
 
         runtimeClasspath.files.each { f ->
-            def url = f.toURL()
+            def url = f.toURI().toURL()
             if (!cloader.getURLs().contains(url)) {
                 method.invoke(cloader, url)
             }


### PR DESCRIPTION
This PR fixes this warning:
```
The AbstractCompile.destinationDir property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the destinationDirectory property instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.1/userguide/upgrading_version_7.html#compile_task_wiring
```

As well as, some other deprecations and minor clean-ups.