### PR TITLE
Change running without normal compilation to a property

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,21 @@ and using the scoverage scalac plugin (`compileScoverageScala`).
 
 In cases where you only wish to generate reports / validate coverage, but are not interested in publishing the code,
 it is possible to only compile the code with the scoverage scalac plugin, thus reducing build times significantly.
-In order to do so, simply add the arguments `-x compileScala` to the gradle execution.
-For example: `gradle reportScoverage -x compileScala`.
+In order to do so, simply add the arguments `-PscoverageCompileOnly` to the gradle execution.
+For example: `gradle reportScoverage -PscoverageCompileOnly`.
 
+Note that this mode is incompatible with parallel builds in multi-module projects.
 
 ### Compatibility with Consistent Versions Plugin
 
 In order for the plugin to work alongside [Palantir's consistent versions plugin](https://github.com/palantir/gradle-consistent-versions),
 the Scala version must be manually configured (via `scoverageScalaVersion`); otherwise, the plugin will attempt to
 resolve the compilation classpath, which is prohibited by the versions plugin.
+
+Migration to 6.1.1
+----------------
+
+* Running without normal compilation is now made with `-PscoverageCompileOnly` instead of `-x compileScala`.
 
 Migration to 5.x
 ----------------

--- a/src/functionalTest/java/org/scoverage/ScalaMultiModuleTest.java
+++ b/src/functionalTest/java/org/scoverage/ScalaMultiModuleTest.java
@@ -23,6 +23,17 @@ public class ScalaMultiModuleTest extends ScoverageFunctionalTest {
     }
 
     @Test
+    public void reportScoverageParallel() {
+
+        AssertableBuildResult result = dryRun("clean", ScoveragePlugin.getREPORT_NAME(), "--parallel");
+
+        result.assertTaskExists(ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskExists("a:" + ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskExists("b:" + ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskExists("common:" + ScoveragePlugin.getREPORT_NAME());
+    }
+
+    @Test
     public void reportScoverageOnlyRoot() {
 
         AssertableBuildResult result = dryRun("clean", ":" + ScoveragePlugin.getREPORT_NAME());
@@ -52,7 +63,7 @@ public class ScalaMultiModuleTest extends ScoverageFunctionalTest {
     public void reportScoverageOnlyAWithoutNormalCompilation() {
 
         AssertableBuildResult result = run("clean", ":a:" + ScoveragePlugin.getREPORT_NAME(),
-                "-x", "compileScala");
+                "-P" + ScoveragePlugin.getSCOVERAGE_COMPILE_ONLY_PROPERTY());
 
         result.assertTaskSkipped("compileScala");
         result.assertTaskSkipped("a:compileScala");
@@ -186,7 +197,7 @@ public class ScalaMultiModuleTest extends ScoverageFunctionalTest {
         AssertableBuildResult result = runAndFail("clean",
                 ":a:test",
                 ":common:test", "--tests", "org.hello.common.TestNothingCommonSuite",
-                "-x", "compileScala",
+                "-P" + ScoveragePlugin.getSCOVERAGE_COMPILE_ONLY_PROPERTY(),
                 ScoveragePlugin.getCHECK_NAME());
 
         result.assertTaskFailed("common:" + ScoveragePlugin.getCHECK_NAME());
@@ -246,7 +257,7 @@ public class ScalaMultiModuleTest extends ScoverageFunctionalTest {
     public void aggregateScoverageWithoutNormalCompilation() throws Exception {
 
         AssertableBuildResult result = run("clean", ScoveragePlugin.getAGGREGATE_NAME(),
-                "-x", "compileScala");
+                "-P" + ScoveragePlugin.getSCOVERAGE_COMPILE_ONLY_PROPERTY());
 
         result.assertTaskSkipped("compileScala");
         result.assertTaskSkipped("a:compileScala");

--- a/src/functionalTest/java/org/scoverage/ScalaMultiModuleWithMultipleTestTasksTest.java
+++ b/src/functionalTest/java/org/scoverage/ScalaMultiModuleWithMultipleTestTasksTest.java
@@ -193,7 +193,7 @@ public class ScalaMultiModuleWithMultipleTestTasksTest extends ScoverageFunction
         AssertableBuildResult result = runAndFail("clean",
                 ":a:test",
                 ":common:test", "--tests", "org.hello.common.TestNothingCommonSuite",
-                "-x", "compileScala",
+                "-P" + ScoveragePlugin.getSCOVERAGE_COMPILE_ONLY_PROPERTY(),
                 ScoveragePlugin.getCHECK_NAME());
 
         result.assertTaskFailed("common:" + ScoveragePlugin.getCHECK_NAME());
@@ -254,7 +254,7 @@ public class ScalaMultiModuleWithMultipleTestTasksTest extends ScoverageFunction
     public void aggregateScoverageWithoutNormalCompilation() throws Exception {
 
         AssertableBuildResult result = run("clean", ScoveragePlugin.getAGGREGATE_NAME(),
-                "-x", "compileScala");
+                "-P" + ScoveragePlugin.getSCOVERAGE_COMPILE_ONLY_PROPERTY());
 
         result.assertTaskSkipped("compileScala");
         result.assertTaskSkipped("a:compileScala");

--- a/src/functionalTest/java/org/scoverage/ScalaSingleModuleTest.java
+++ b/src/functionalTest/java/org/scoverage/ScalaSingleModuleTest.java
@@ -103,7 +103,7 @@ public class ScalaSingleModuleTest extends ScoverageFunctionalTest {
     public void reportScoverageWithoutNormalCompilation() throws Exception {
 
         AssertableBuildResult result = run("clean", ScoveragePlugin.getREPORT_NAME(),
-                "-x", "compileScala");
+                "-P" + ScoveragePlugin.getSCOVERAGE_COMPILE_ONLY_PROPERTY());
 
         result.assertTaskSkipped("compileScala");
         result.assertTaskSucceeded(ScoveragePlugin.getCOMPILE_NAME());
@@ -122,7 +122,7 @@ public class ScalaSingleModuleTest extends ScoverageFunctionalTest {
     public void reportScoverageWithoutNormalCompilationAndWithExcludedClasses() throws Exception {
 
         AssertableBuildResult result = run("clean", ScoveragePlugin.getREPORT_NAME(),
-                "-PexcludedFile=.*", "-x", "compileScala");
+                "-PexcludedFile=.*", "-P" + ScoveragePlugin.getSCOVERAGE_COMPILE_ONLY_PROPERTY());
 
         Assert.assertTrue(resolve(reportDir(), "index.html").exists());
         Assert.assertFalse(resolve(reportDir(), "src/main/scala/org/hello/World.scala.html").exists());

--- a/src/functionalTest/java/org/scoverage/ScalaSingleModuleWithMultipleTestTasksTest.java
+++ b/src/functionalTest/java/org/scoverage/ScalaSingleModuleWithMultipleTestTasksTest.java
@@ -121,7 +121,7 @@ public class ScalaSingleModuleWithMultipleTestTasksTest extends ScoverageFunctio
     public void reportScoverageWithoutNormalCompilation() throws Exception {
 
         AssertableBuildResult result = run("clean", ScoveragePlugin.getREPORT_NAME(),
-                "-x", "compileScala");
+                "-P" + ScoveragePlugin.getSCOVERAGE_COMPILE_ONLY_PROPERTY());
 
         result.assertTaskSkipped("compileScala");
         result.assertTaskSucceeded(ScoveragePlugin.getCOMPILE_NAME());
@@ -140,7 +140,7 @@ public class ScalaSingleModuleWithMultipleTestTasksTest extends ScoverageFunctio
     public void reportScoverageWithoutNormalCompilationAndWithExcludedClasses() throws Exception {
 
         AssertableBuildResult result = run("clean", ScoveragePlugin.getREPORT_NAME(),
-                "-PexcludedFile=.*", "-x", "compileScala");
+                "-PexcludedFile=.*", "-P" + ScoveragePlugin.getSCOVERAGE_COMPILE_ONLY_PROPERTY());
 
         Assert.assertTrue(resolve(reportDir(), "index.html").exists());
         Assert.assertFalse(resolve(reportDir(), "src/main/scala/org/hello/World.scala.html").exists());


### PR DESCRIPTION
Fixes #153, #150.

This PR changes the way that running without normal compilation is enabled, from `-x compileScala` to `-PscoverageCompileOnly`.

This allows the plugin to detect that this option is selected earlier in the configuration stage, so then it can perform certain actions -- such as depending on dependent projects' scoverage compile tasks -- only if the option is enabled.

This should resolve #153 and also provide a partial solution to #150, so now parallel mode will work with normal compilation and will only fail to work without normal compilation (in multi-module projects).