### PR TITLE
Bump scoverage version from 1.4.8 to 1.4.11 to fix Scala 2.12.15 compatibility

### DIFF
--- a/src/main/groovy/org/scoverage/ScoverageExtension.groovy
+++ b/src/main/groovy/org/scoverage/ScoverageExtension.groovy
@@ -55,7 +55,7 @@ class ScoverageExtension {
         project.plugins.apply(ScalaPlugin.class)
 
         scoverageVersion = project.objects.property(String)
-        scoverageVersion.set('1.4.8')
+        scoverageVersion.set('1.4.10')
 
         scoverageScalaVersion = project.objects.property(String)
 

--- a/src/main/groovy/org/scoverage/ScoverageExtension.groovy
+++ b/src/main/groovy/org/scoverage/ScoverageExtension.groovy
@@ -55,7 +55,7 @@ class ScoverageExtension {
         project.plugins.apply(ScalaPlugin.class)
 
         scoverageVersion = project.objects.property(String)
-        scoverageVersion.set('1.4.10')
+        scoverageVersion.set('1.4.11')
 
         scoverageScalaVersion = project.objects.property(String)
 


### PR DESCRIPTION
As described in #174, currently this plugin is broken when using Scala 2.12.15. This PR fixes it by bumping the scoverage version from 1.4.18 to 1.4.11.