### PR TITLE
Change warn level to info when sub-projects are excluded.

### DIFF
--- a/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
+++ b/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
@@ -297,7 +297,7 @@ class ScoveragePlugin implements Plugin<PluginAware> {
                 project.gradle.projectsEvaluated {
                     project.subprojects.each {
                         if (it.plugins.hasPlugin(ScalaPlugin) && !it.plugins.hasPlugin(ScoveragePlugin)) {
-                            it.logger.warn("Scala sub-project '${it.name}' doesn't have Scoverage applied and will be ignored in parent project aggregation")
+                            it.logger.info("Scala sub-project '${it.name}' doesn't have Scoverage applied and will be ignored in parent project aggregation")
                         }
                     }
                     def childReportTasks = project.subprojects.findResults {


### PR DESCRIPTION
In some cases we have intentionally omitted some sub-projects from being instrumented with scoverage, which causes the log output to be spammed with this message. This sets the log level to `info` which is more consistent with the rest of the codebase and prevents spamming logs when projects are excluded from the coverage reports.
