### PR TITLE
Bump up scoverageVersion from 1.4.8 to 1.4.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can find instructions on how to apply the plugin at http://plugins.gradle.or
 The plugin exposes multiple options that can be configured by setting them in an `scoverage` block within the project's
 build script. These options are as follows:
 
-* `scoverageVersion = <String>` (default `"1.4.8`): The version of the scoverage scalac plugin. This (gradle) plugin
+* `scoverageVersion = <String>` (default `1.4.11`): The version of the scoverage scalac plugin. This (gradle) plugin
 should be compatible with all 1+ versions.
 
 * `scoverageScalaVersion = <String>` (default `detected`): The scala version of the scoverage scalac plugin. This

--- a/src/main/groovy/org/scoverage/ScoverageExtension.groovy
+++ b/src/main/groovy/org/scoverage/ScoverageExtension.groovy
@@ -55,7 +55,7 @@ class ScoverageExtension {
         project.plugins.apply(ScalaPlugin.class)
 
         scoverageVersion = project.objects.property(String)
-        scoverageVersion.set('1.4.8')
+        scoverageVersion.set('1.4.11')
 
         scoverageScalaVersion = project.objects.property(String)
 


### PR DESCRIPTION
`gradle checkScoverage` got the following error, so upgrade version to 1.4.11.

```bash
> Could not resolve all files for configuration ':experiments:scoverage'.
   > Could not find org.scoverage:scalac-scoverage-plugin_2.13.8:1.4.8.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/org/scoverage/scalac-scoverage-plugin_2.13.8/1.4.8/scalac-scoverage-plugin_2.13.8-1.4.8.pom
       - file:/Users/jiahuili/src/ziose/deps/scalac-scoverage-plugin_2.13.8-1.4.8.jar
       - file:/Users/jiahuili/src/ziose/deps/scalac-scoverage-plugin_2.13.8.jar
     Required by:
         project :experiment
```