### PR TITLE
Fix coverageDebug = true

### DIFF
--- a/src/main/groovy/org/scoverage/ScoverageWriter.java
+++ b/src/main/groovy/org/scoverage/ScoverageWriter.java
@@ -105,7 +105,7 @@ public class ScoverageWriter {
                 File.separator +
                 Constants.XMLReportFilename());
             if (coverageDebug) {
-                ScoverageXmlWriter writerDebug = cst.newInstance(sourceDirsSeq, reportDir, true);
+                ScoverageXmlWriter writerDebug = cst.newInstance(sourceDirsSeq, reportDir, true, new Some<>(sourceEncoding));
                 writerDebug.write(coverage);
                 logger.info("[scoverage] Written XML report with debug information to " +
                     reportDir.getAbsolutePath() +


### PR DESCRIPTION
Scala 3 / Scoverage 2.0.7 support added in 206a7843dfdb missed updating construction of the debug writer. This is addressed here.