### PR TITLE
Add support for excludedFiles and excludedPackages for Scala 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can find instructions on how to apply the plugin at http://plugins.gradle.or
 The plugin exposes multiple options that can be configured by setting them in an `scoverage` block within the project's
 build script. These options are as follows:
 
-* `scoverageVersion = <String>` (default `"1.4.8`): The version of the scoverage scalac plugin. This (gradle) plugin
+* `scoverageVersion = <String>` (default `"2.1.1`): The version of the scoverage scalac plugin. This (gradle) plugin
 should be compatible with all 1+ versions.
 
 * `scoverageScalaVersion = <String>` (default `detected`): The scala version of the scoverage scalac plugin. This
@@ -63,6 +63,10 @@ required for the validation to pass (otherwise `checkScoverage` will fail the bu
 * `coverageType = <CoverageType.Statement | CoverageType.Branch | CoverageType.Line>` (default `CoverageType.Statement`): The type of coverage validated by the
 `checkScoverage` task. For more information on the different types, please refer to the documentation of the scalac
 plugin (https://github.com/scoverage/scalac-scoverage-plugin).
+
+* `excludedFiles = <files>` (default `not set`): Comma separated list of regexes for files to exclude from coverage.
+
+* `excludedPackages = <packages, classes and modules>` (default `not set`): Comma separated list of regexes for packages, classes and modules to exclude from coverage.
 
 #### Multiple check tasks
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,13 +38,15 @@ gradlePlugin {
 apply plugin: 'maven-publish'
 apply plugin: 'groovy'
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
-
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 dependencies {
-    compileOnly "org.scoverage:scalac-scoverage-plugin_2.13.8:2.0.7"
-    compileOnly "org.scoverage:scalac-scoverage-reporter_2.13:2.0.7"
+    compileOnly 'org.scoverage:scalac-scoverage-plugin_2.13.14:2.1.1'
+    compileOnly 'org.scoverage:scalac-scoverage-reporter_2.13:2.1.1'
+
     implementation group: 'commons-io', name: 'commons-io', version: '2.6'
 
     testImplementation 'junit:junit:4.12'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
-distributionSha256Sum=e111cb9948407e26351227dabce49822fb88c37ee72f1d1582a69c68af2e702f
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionSha256Sum=a4b4158601f8636cdeeab09bd76afb640030bb5b144aafe261a5e8af027dc612
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/crossScalaVersionTest/resources/projects/scala-multi-module-cross-version/3_2/build.gradle
+++ b/src/crossScalaVersionTest/resources/projects/scala-multi-module-cross-version/3_2/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation 'org.scala-lang:scala3-library_3:3.2.0'
-    testImplementation 'org.scalatest:scalatest_3:3.2.14'
-    testImplementation "org.scalatestplus:junit-4-13_3:3.2.14.0"
+    implementation 'org.scala-lang:scala3-library_3:3.4.2'
+    testImplementation 'org.scalatest:scalatest_3:3.2.16'
+    testImplementation "org.scalatestplus:junit-4-13_3:3.2.16.0"
 }

--- a/src/functionalTest/java/org/scoverage/ScalaSingleModuleTest.java
+++ b/src/functionalTest/java/org/scoverage/ScalaSingleModuleTest.java
@@ -4,10 +4,17 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.List;
+
 public class ScalaSingleModuleTest extends ScoverageFunctionalTest {
 
     public ScalaSingleModuleTest() {
         super("scala-single-module");
+    }
+
+    @Override
+    protected List<String> getVersionAgruments() {
+        return ScalaVersionArguments.version2;
     }
 
     @Test

--- a/src/functionalTest/java/org/scoverage/ScalaSingleModuleTest.java
+++ b/src/functionalTest/java/org/scoverage/ScalaSingleModuleTest.java
@@ -135,7 +135,7 @@ public class ScalaSingleModuleTest extends ScoverageFunctionalTest {
         Assert.assertFalse(resolve(buildDir(), "classes/scala/scoverage/org/hello/World.class").exists());
     }
 
-    private void assertReportFilesExist() {
+    protected void assertReportFilesExist() {
 
         Assert.assertTrue(resolve(reportDir(), "index.html").exists());
         Assert.assertTrue(resolve(reportDir(), "org/hello/World.scala.html").exists());

--- a/src/functionalTest/java/org/scoverage/ScalaSingleModuleTestScala3.java
+++ b/src/functionalTest/java/org/scoverage/ScalaSingleModuleTestScala3.java
@@ -1,0 +1,57 @@
+package org.scoverage;
+
+import org.junit.Assert;
+
+import java.util.List;
+
+public class ScalaSingleModuleTestScala3 extends ScalaSingleModuleTest {
+
+    @Override
+    protected List<String> getVersionAgruments() {
+        return ScalaVersionArguments.version3;
+    }
+
+    @Override
+    public void checkScoverage() throws Exception {
+        AssertableBuildResult result = run("clean", ScoveragePlugin.getCHECK_NAME());
+
+        result.assertTaskSucceeded(ScoveragePlugin.getCOMPILE_NAME());
+        result.assertTaskSucceeded(ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskSucceeded(ScoveragePlugin.getCHECK_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getAGGREGATE_NAME());
+
+        assertReportFilesExist();
+        assertCoverage(66.67);
+    }
+
+    @Override
+    public void reportScoverageWithExcludedClasses() throws Exception {
+        AssertableBuildResult result = run("clean", ScoveragePlugin.getREPORT_NAME(),
+                "-PexcludedFile=.*");
+
+        result.assertTaskSucceeded(ScoveragePlugin.getCOMPILE_NAME());
+        result.assertTaskSucceeded(ScoveragePlugin.getREPORT_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getCHECK_NAME());
+        result.assertTaskDoesntExist(ScoveragePlugin.getAGGREGATE_NAME());
+
+        Assert.assertTrue(resolve(reportDir(), "index.html").exists());
+        Assert.assertFalse(resolve(reportDir(), "org/hello/World.scala.html").exists());
+        assertCoverage(100.0); // coverage is 100 since no classes are covered
+
+        // compiled class should exist in the default classes directory, but not in scoverage
+        Assert.assertTrue(resolve(buildDir(), "classes/scala/main/org/hello/World.class").exists());
+    }
+
+    @Override
+    public void reportScoverageWithoutNormalCompilationAndWithExcludedClasses() throws Exception {
+        AssertableBuildResult result = run("clean", ScoveragePlugin.getREPORT_NAME(),
+                "-PexcludedFile=.*", "-P" + ScoveragePlugin.getSCOVERAGE_COMPILE_ONLY_PROPERTY());
+
+        Assert.assertTrue(resolve(reportDir(), "index.html").exists());
+        Assert.assertFalse(resolve(reportDir(), "org/hello/World.scala.html").exists());
+        assertCoverage(100.0); // coverage is 100 since no classes are covered
+
+        // compiled class should exist in the default classes directory, but not in scoverage
+        Assert.assertTrue(resolve(buildDir(), "classes/scala/main/org/hello/World.class").exists());
+    }
+}

--- a/src/functionalTest/java/org/scoverage/ScalaVersionArguments.java
+++ b/src/functionalTest/java/org/scoverage/ScalaVersionArguments.java
@@ -1,0 +1,24 @@
+package org.scoverage;
+
+import java.util.Arrays;
+import java.util.List;
+
+public interface ScalaVersionArguments {
+    List<String> version2 = Arrays.asList(
+            "-PscalaVersionMajor=2",
+            "-PscalaVersionMinor=13",
+            "-PscalaVersionBuild=14",
+            "-PjunitVersion=5.3.2",
+            "-PjunitPlatformVersion=1.3.2",
+            "-PscalatestVersion=3.2.16"
+    );
+
+    List<String> version3 = Arrays.asList(
+            "-PscalaVersionMajor=3",
+            "-PscalaVersionMinor=4",
+            "-PscalaVersionBuild=2",
+            "-PjunitVersion=5.3.2",
+            "-PjunitPlatformVersion=1.3.2",
+            "-PscalatestVersion=3.2.16"
+    );
+}

--- a/src/functionalTest/java/org/scoverage/ScalaVersionArguments.java
+++ b/src/functionalTest/java/org/scoverage/ScalaVersionArguments.java
@@ -4,6 +4,15 @@ import java.util.Arrays;
 import java.util.List;
 
 public interface ScalaVersionArguments {
+    List<String> version2WithLegacyScalatest = Arrays.asList(
+            "-PscalaVersionMajor=2",
+            "-PscalaVersionMinor=13",
+            "-PscalaVersionBuild=14",
+            "-PjunitVersion=5.3.2",
+            "-PjunitPlatformVersion=1.3.2",
+            "-PscalatestVersion=3.0.8"
+    );
+
     List<String> version2 = Arrays.asList(
             "-PscalaVersionMajor=2",
             "-PscalaVersionMinor=13",

--- a/src/functionalTest/java/org/scoverage/ScoverageFunctionalTest.java
+++ b/src/functionalTest/java/org/scoverage/ScoverageFunctionalTest.java
@@ -116,7 +116,7 @@ public abstract class ScoverageFunctionalTest {
     }
 
     protected List<String> getVersionAgruments() {
-        return ScalaVersionArguments.version2;
+        return ScalaVersionArguments.version2WithLegacyScalatest;
     }
 
     private void configureArguments(String... arguments) {

--- a/src/functionalTest/java/org/scoverage/ScoverageFunctionalTest.java
+++ b/src/functionalTest/java/org/scoverage/ScoverageFunctionalTest.java
@@ -121,7 +121,7 @@ public abstract class ScoverageFunctionalTest {
 
         fullArguments.add("-PscalaVersionMajor=2");
         fullArguments.add("-PscalaVersionMinor=13");
-        fullArguments.add("-PscalaVersionBuild=10");
+        fullArguments.add("-PscalaVersionBuild=14");
         fullArguments.add("-PjunitVersion=5.3.2");
         fullArguments.add("-PjunitPlatformVersion=1.3.2");
         fullArguments.add("-PscalatestVersion=3.0.8");

--- a/src/functionalTest/java/org/scoverage/ScoverageFunctionalTest.java
+++ b/src/functionalTest/java/org/scoverage/ScoverageFunctionalTest.java
@@ -115,16 +115,14 @@ public abstract class ScoverageFunctionalTest {
         return coverageType.normalize(rawValue) * 100.0;
     }
 
+    protected List<String> getVersionAgruments() {
+        return ScalaVersionArguments.version2;
+    }
+
     private void configureArguments(String... arguments) {
 
-        List<String> fullArguments = new ArrayList<>();
+        List<String> fullArguments = new ArrayList<>(getVersionAgruments());
 
-        fullArguments.add("-PscalaVersionMajor=2");
-        fullArguments.add("-PscalaVersionMinor=13");
-        fullArguments.add("-PscalaVersionBuild=14");
-        fullArguments.add("-PjunitVersion=5.3.2");
-        fullArguments.add("-PjunitPlatformVersion=1.3.2");
-        fullArguments.add("-PscalatestVersion=3.0.8");
         if (Boolean.parseBoolean(System.getProperty("failOnWarning"))) {
             fullArguments.add("--warning-mode=fail");
         } else {

--- a/src/functionalTest/resources/projects/detect-scala-library/dependency-management/build.gradle
+++ b/src/functionalTest/resources/projects/detect-scala-library/dependency-management/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.spring.dependency-management' version "1.0.4.RELEASE"
+    id 'io.spring.dependency-management' version "1.1.5"
     id 'org.scoverage'
 }
 

--- a/src/functionalTest/resources/projects/scala-single-module-dependency-manager/build.gradle
+++ b/src/functionalTest/resources/projects/scala-single-module-dependency-manager/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.spring.dependency-management' version "1.0.4.RELEASE"
+    id 'io.spring.dependency-management' version "1.1.5"
     id 'org.scoverage'
 }
 

--- a/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/build.gradle
+++ b/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.spring.dependency-management' version "1.0.4.RELEASE"
+    id 'io.spring.dependency-management' version "1.1.5"
     id 'org.scoverage'
     id 'jvm-test-suite'
 }

--- a/src/functionalTest/resources/projects/scala-single-module/build.gradle
+++ b/src/functionalTest/resources/projects/scala-single-module/build.gradle
@@ -12,12 +12,20 @@ apply plugin: 'java'
 apply plugin: 'scala'
 
 dependencies {
-    implementation group: 'org.scala-lang', name: 'scala-library', version: "${scalaVersionMajor}.${scalaVersionMinor}.${scalaVersionBuild}"
+    if (project.getProperties().get("scalaVersionMajor").equals("2")) {
+        implementation group: 'org.scala-lang', name: 'scala-library', version: "${scalaVersionMajor}.${scalaVersionMinor}.${scalaVersionBuild}"
+
+        testImplementation group: 'org.scalatest', name: 'scalatest_2.13', version: scalatestVersion
+        testImplementation group: 'org.scalatestplus', name: 'junit-4-13_2.13', version: "${scalatestVersion}.0"
+    } else {
+        implementation group: 'org.scala-lang', name: 'scala3-library_3', version: "${scalaVersionMajor}.${scalaVersionMinor}.${scalaVersionBuild}"
+
+        testImplementation group: 'org.scalatest', name: 'scalatest_3', version: scalatestVersion
+        testImplementation group: 'org.scalatestplus', name: 'junit-4-13_3', version: "${scalatestVersion}.0"
+    }
 
     testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: junitVersion
     testImplementation group: 'org.junit.platform', name: 'junit-platform-runner', version: junitPlatformVersion
-
-    testImplementation group: 'org.scalatest', name: "scalatest_${scalaVersionMajor}.${scalaVersionMinor}", version: scalatestVersion
 }
 
 test {

--- a/src/functionalTest/resources/projects/scala-single-module/src/test/scala/org/hello/TestNothingSuite.scala
+++ b/src/functionalTest/resources/projects/scala-single-module/src/test/scala/org/hello/TestNothingSuite.scala
@@ -1,11 +1,11 @@
 package org.hello
 
 import org.junit.runner.RunWith
-import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
+import org.scalatest.funsuite._
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class TestNothingSuite extends FunSuite {
+class TestNothingSuite extends AnyFunSuite {
 
   test("nothing") {
   }

--- a/src/functionalTest/resources/projects/scala-single-module/src/test/scala/org/hello/WorldSuite.scala
+++ b/src/functionalTest/resources/projects/scala-single-module/src/test/scala/org/hello/WorldSuite.scala
@@ -1,11 +1,11 @@
 package org.hello
 
 import org.junit.runner.RunWith
-import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
+import org.scalatest.funsuite._
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class WorldSuite extends FunSuite {
+class WorldSuite extends AnyFunSuite {
 
   test("foo") {
     new World().foo()

--- a/src/main/groovy/org/scoverage/ScoverageExtension.groovy
+++ b/src/main/groovy/org/scoverage/ScoverageExtension.groovy
@@ -55,7 +55,7 @@ class ScoverageExtension {
         project.plugins.apply(ScalaPlugin.class)
 
         scoverageVersion = project.objects.property(String)
-        scoverageVersion.set('2.0.8')
+        scoverageVersion.set('2.1.1')
 
         scoverageScalaVersion = project.objects.property(String)
 

--- a/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
+++ b/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
@@ -206,6 +206,14 @@ class ScoveragePlugin implements Plugin<PluginAware> {
                 } else {
                     parameters.add("-sourceroot:${project.rootDir.absolutePath}".toString())
                     parameters.add("-coverage-out:${extension.dataDir.get().absolutePath}".toString())
+                    if (extension.excludedPackages.get()) {
+                        def packages = extension.excludedPackages.get().join(',')
+                        parameters.add("-coverage-exclude-classlikes:$packages".toString())
+                    }
+                    if (extension.excludedFiles.get()) {
+                        def packages = extension.excludedFiles.get().join(';')
+                        parameters.add("-coverage-exclude-files:$packages".toString())
+                    }
                     scalaCompileOptions.additionalParameters = parameters
                 }
             }

--- a/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
+++ b/src/main/groovy/org/scoverage/ScoveragePlugin.groovy
@@ -24,7 +24,7 @@ class ScoveragePlugin implements Plugin<PluginAware> {
     static final String CHECK_NAME = 'checkScoverage'
     static final String COMPILE_NAME = 'compileScoverageScala'
     static final String AGGREGATE_NAME = 'aggregateScoverage'
-    static final String DEFAULT_SCALA_VERSION = '2.13.6'
+    static final String DEFAULT_SCALA_VERSION = '2.13.14'
     static final String SCOVERAGE_COMPILE_ONLY_PROPERTY = 'scoverageCompileOnly';
 
     static final String DEFAULT_REPORT_DIR = 'reports' + File.separatorChar + 'scoverage'


### PR DESCRIPTION
Implemented excludedFiles and excludedPackages for Scala 3 based on the following Scala 3 pull request:
https://github.com/scala/scala3/pull/19727/files

Library upgrades:
- Gradle version to 8.8
- Scoverage version to 2.1.1
- Scala 2 version to 2.13.14
- Scala 3 version to 3.4.2