### PR TITLE
Upgrade to gradle 9.2.0 and remove obsolete testType property

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
-distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionSha256Sum=df67a32e86e3276d011735facb1535f64d0d88df84fa87521e90becc2d735444
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/functionalTest/resources/projects/scala-multi-module-multiple-test-tasks/build.gradle
+++ b/src/functionalTest/resources/projects/scala-multi-module-multiple-test-tasks/build.gradle
@@ -36,7 +36,6 @@ allprojects {
                 }
             }
             intTest(JvmTestSuite) {
-                testType = TestSuiteType.INTEGRATION_TEST
                 // dependencies { ... } does not appear to work as advertised?
                 sources {
                     scala {

--- a/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/build.gradle
+++ b/src/functionalTest/resources/projects/scala-single-module-multiple-test-tasks/build.gradle
@@ -39,7 +39,6 @@ testing {
             }
         }
         intTest(JvmTestSuite) {
-            testType = TestSuiteType.INTEGRATION_TEST
             // dependencies { ... } does not appear to work as advertised?
             sources {
                 scala {


### PR DESCRIPTION
This MR upgrade Gradle to 9.2.0 and remove obsolete testType property to fix the build